### PR TITLE
Make library no_std compatible by adding a "std" cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,12 @@ license = "Unlicense"
 # To disable all features, run `cargo build` with the `--no-default-features` option.
 # Doing  This only includes the constants.
 [features]
-default = ["unicode"]
+default = ["unicode", "std"]
 
 # adds strong-typed unicode encoding and decoding, as well
 # as Default, Debug, Display, Clone, implementations.
 unicode = []
+
+# Disabling this feature removes the dependency on the standard library
+# and makes the library no_std compatible.
+std = []

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -1,7 +1,7 @@
 //! Basic Latin. `U+0000` - `U+007F`
 use super::{FontUtf16, Utf16Fonts, legacy::BASIC_LEGACY};
 
-use std::fmt;
+use core::fmt;
 
 /// A constant `[FontUtf16; 128]`, for Basic Latin fonts (`U+0000` - `U+007F`).
 ///
@@ -1439,6 +1439,7 @@ impl Utf16Fonts for BasicFonts {
         }
     }
 
+    #[cfg(feature = "std")]
     fn print_set(&self) {
         println!();
         println!("# `{:?}`", self);
@@ -1470,6 +1471,7 @@ impl Utf16Fonts for BasicFonts {
         }
     }
 
+    #[cfg(feature = "std")]
     fn to_vec(&self) -> Vec<(u16, FontUtf16)> {
         self.0.into_iter().fold(Vec::with_capacity(128), |mut v, font| {
             v.push((font.utf16(), *font));

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,6 +1,6 @@
 //!  Block Elements. `U+2580` - `U+259F`
 use super::{legacy::BLOCK_LEGACY, FontUtf16, Utf16Fonts};
-use std::fmt;
+use core::fmt;
 
 /// A constant `[FontUtf16; 32]`, for Block Element fonts (`U+2580` - `U+259F`).
 ///
@@ -503,6 +503,7 @@ impl Utf16Fonts for BlockFonts {
         }
     }
 
+    #[cfg(feature = "std")]
     fn print_set(&self) {
         println!();
         println!("# `{:?}`", self);
@@ -534,6 +535,7 @@ impl Utf16Fonts for BlockFonts {
         }
     }
 
+    #[cfg(feature = "std")]
     fn to_vec(&self) -> Vec<(u16, FontUtf16)> {
         self.0.into_iter().fold(Vec::with_capacity(128), |mut v, font| {
             v.push((font.utf16(), *font));

--- a/src/box.rs
+++ b/src/box.rs
@@ -1,6 +1,6 @@
 //!  Box Drawing. `U+2500 - U+257F`
 use super::{legacy::BOX_LEGACY, FontUtf16, Utf16Fonts};
-use std::fmt;
+use core::fmt;
 
 /// A constant `[FontUtf16; 128]`, for Box Element fonts (`U+2500` - `U+257F`).
 ///
@@ -1846,6 +1846,7 @@ impl Utf16Fonts for BoxFonts {
         }
     }
 
+    #[cfg(feature = "std")]
     fn print_set(&self) {
         println!();
         println!("# `{:?}`", self);
@@ -1877,6 +1878,7 @@ impl Utf16Fonts for BoxFonts {
         }
     }
 
+    #[cfg(feature = "std")]
     fn to_vec(&self) -> Vec<(u16, FontUtf16)> {
         self.0.into_iter().fold(Vec::with_capacity(128), |mut v, font| {
             v.push((font.utf16(), *font));

--- a/src/greek.rs
+++ b/src/greek.rs
@@ -1,6 +1,6 @@
 //! Greek Characters. `U+0390 - U+03C9`
 use super::{legacy::GREEK_LEGACY, FontUtf16, Utf16Fonts};
-use std::fmt;
+use core::fmt;
 
 /// A constant `[FontUtf16; 128]`, for Greek fonts (`U+0390` - `U+03C9`).
 pub const GREEK_UTF16: [FontUtf16; 58] = [
@@ -112,6 +112,7 @@ impl Utf16Fonts for GreekFonts {
         }
     }
 
+    #[cfg(feature = "std")]
     fn print_set(&self) {
         println!();
         println!("# `{:?}`", self);
@@ -143,6 +144,7 @@ impl Utf16Fonts for GreekFonts {
         }
     }
 
+    #[cfg(feature = "std")]
     fn to_vec(&self) -> Vec<(u16, FontUtf16)> {
         self.0.into_iter().fold(Vec::with_capacity(128), |mut v, font| {
             v.push((font.utf16(), *font));

--- a/src/hiragana.rs
+++ b/src/hiragana.rs
@@ -1,6 +1,6 @@
 //! Hiragana. `U+3040 - U+309F`
 use super::{legacy::HIRAGANA_LEGACY, FontUtf16, Utf16Fonts};
-use std::fmt;
+use core::fmt;
 
 /// A constant `[FontUtf16; 96]`, for Hiragana fonts (`U+3040` - `U+309F`).
 pub const HIRAGANA_UTF16: [FontUtf16; 96] = [
@@ -150,6 +150,7 @@ impl Utf16Fonts for HiraganaFonts {
         }
     }
 
+    #[cfg(feature = "std")]
     fn print_set(&self) {
         println!();
         println!("# `{:?}`", self);
@@ -181,6 +182,7 @@ impl Utf16Fonts for HiraganaFonts {
         }
     }
 
+    #[cfg(feature = "std")]
     fn to_vec(&self) -> Vec<(u16, FontUtf16)> {
         self.0.into_iter().fold(Vec::with_capacity(128), |mut v, font| {
             v.push((font.utf16(), *font));

--- a/src/latin.rs
+++ b/src/latin.rs
@@ -1,6 +1,6 @@
 //! Extended Latin. `U+00A0 - U+00FF`
 use super::{legacy::LATIN_LEGACY, utf16::{FontUtf16, Utf16Fonts}};
-use std::fmt;
+use core::fmt;
 
 /// A constant `[FontUtf16; 96]`, for Extended Latin fonts (`U+00A0` - `U+00FF`).
 ///
@@ -1374,6 +1374,7 @@ impl Utf16Fonts for LatinFonts {
         }
     }
 
+    #[cfg(feature = "std")]
     fn print_set(&self) {
         println!();
         println!("# `{:?}`", self);
@@ -1405,6 +1406,7 @@ impl Utf16Fonts for LatinFonts {
         }
     }
 
+    #[cfg(feature = "std")]
     fn to_vec(&self) -> Vec<(u16, FontUtf16)> {
         self.0.into_iter().fold(Vec::with_capacity(128), |mut v, font| {
             v.push((font.utf16(), *font));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,13 +53,13 @@
 //!
 //! The generated output should mostly resemble this (it will depend on your terminal's font settings):
 //! ```text
-//!  █ ██ █  
-//!          
-//!    ██    
-//!    ██    
-//!    ██    
-//!    ██ █  
-//!     ██   
+//!  █ ██ █
+//!
+//!    ██
+//!    ██
+//!    ██
+//!    ██ █
+//!     ██
 //! ```
 //!
 //! and, it's meant to look like this: `ΐ`.
@@ -103,6 +103,9 @@
 //! [https://github.com/dhepper/font8x8](https://github.com/dhepper/font8x8).
 //!
 //! This crate is an extension of that work.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
 #[cfg(feature = "unicode")]
 mod basic;
 #[cfg(feature = "unicode")]
@@ -151,4 +154,11 @@ pub use self::misc::MISC_FONTS;
 pub use self::sga::SGA_FONTS;
 
 #[cfg(feature = "unicode")]
-pub use self::utf16::{FontUtf16, FromUtf16Error, Utf16Fonts};
+pub use self::utf16::{FontUtf16, Utf16Fonts};
+#[cfg(all(feature = "unicode", feature = "std"))]
+pub use self::utf16::FromUtf16Error;
+
+#[cfg(feature = "std")]
+mod core {
+    pub use std::*;
+}

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -1,6 +1,6 @@
 //! A miscellanous set of characters.
 use super::{legacy::MISC_LEGACY, FontUtf16, Utf16Fonts};
-use std::fmt;
+use core::fmt;
 
 /// A constant `[FontUtf16; 10]`, for  Miscellanous fonts (`U+20A7`, `U+0192`, `U+00AA`,
 /// `U+00BA`, `U+2310`, `U+2264`, `U+2265`, `U+0060`, `U+1EF2`, and `U+1EF3`).
@@ -66,6 +66,7 @@ impl Utf16Fonts for MiscFonts {
         }
     }
 
+    #[cfg(feature = "std")]
     fn print_set(&self) {
         println!();
         println!("# `{:?}`", self);
@@ -97,6 +98,7 @@ impl Utf16Fonts for MiscFonts {
         }
     }
 
+    #[cfg(feature = "std")]
     fn to_vec(&self) -> Vec<(u16, FontUtf16)> {
         self.0.into_iter().fold(Vec::with_capacity(128), |mut v, font| {
             v.push((font.utf16(), *font));

--- a/src/sga.rs
+++ b/src/sga.rs
@@ -1,6 +1,6 @@
 //! Special characters with private unicode points.
 use super::{legacy::SGA_LEGACY, utf16::{FontUtf16, Utf16Fonts}};
-use std::fmt;
+use core::fmt;
 
 /// A constant `[FontUtf16; 26]`, for special SGA fonts (`U+E543` - `U+E55A`).
 ///
@@ -418,6 +418,7 @@ impl Utf16Fonts for SgaFonts {
         }
     }
 
+    #[cfg(feature = "std")]
     fn print_set(&self) {
         println!();
         println!("# `{:?}`", self);
@@ -426,6 +427,7 @@ impl Utf16Fonts for SgaFonts {
         }
     }
 
+    #[cfg(feature = "std")]
     fn to_vec(&self) -> Vec<(u16, FontUtf16)> {
         self.0.into_iter().fold(Vec::with_capacity(128), |mut v, font| {
             v.push((font.utf16(), *font));
@@ -433,6 +435,8 @@ impl Utf16Fonts for SgaFonts {
         })
     }
 }
+
+#[cfg(feature = "std")]
 fn print_set(idx: usize, font: &FontUtf16) {
     if font.is_whitespace() {
         println!("## {:3?}: 0x{:04X} \" \"", idx, font.utf16());

--- a/src/utf16.rs
+++ b/src/utf16.rs
@@ -8,6 +8,7 @@ pub use super::hiragana::{HIRAGANA_UTF16, HiraganaFonts};
 pub use super::latin::{LATIN_UTF16, LatinFonts};
 pub use super::misc::{MISC_UTF16, MiscFonts};
 pub use super::sga::{SGA_UTF16, SgaFonts};
+#[cfg(feature = "std")]
 pub use std::string::FromUtf16Error;
 
 /// A single 8x8 font which supports `UTF-16` encoding/decoding.
@@ -24,6 +25,7 @@ impl FontUtf16 {
         self.1
     }
     /// Return a result with the corresponding `String` for the font.
+    #[cfg(feature = "std")]
     pub fn to_string(&self) -> String {
         String::from_utf16(&[self.0]).unwrap()
     }
@@ -61,8 +63,13 @@ impl Into<(u16, [u8; 8])> for FontUtf16 {
 /// the `[u8; 8]` by key, using the corresponding Unicode value, encoded as UTF-16 (`u16`).
 pub trait Utf16Fonts {
     fn get(&self, key: u16) -> Option<[u8; 8]>;
+
     fn get_font(&self, key: u16) -> Option<FontUtf16>;
+
+    #[cfg(feature = "std")]
     fn print_set(&self);
+
+    #[cfg(feature = "std")]
     fn to_vec(&self) -> Vec<(u16, FontUtf16)>;
 }
 


### PR DESCRIPTION
Hi, thanks for the awesome library!

We want to use it in the embedded context, where we don't have access to the standard library. This PR makes the library `no_std` compatible by adding a "std" cargo feature that is turned on by default. We use this feature to conditionally compile everything that depends on std, such as the `print_set` and `to_vec` methods.